### PR TITLE
Add a marker block that can ignore the i18n-ize script to i18n-ize the c...

### DIFF
--- a/i18nize_templates/__init__.py
+++ b/i18nize_templates/__init__.py
@@ -1778,6 +1778,8 @@ class DjangoHtmlLexer(HtmlLexer):
         tags = (('{#', '#}', True),
                 ('{% comment %}', '{% endcomment %}', True),
                 ('{% blocktrans', '{% endblocktrans %}', True),
+                ('{% block i18n_do_not_translate %}', '{% endblock i18n_do_not_translate %}', True),
+
                 ('{% if', '{% endif %}', True),
                 ('{%', '%}', True),
                 ('{{', '}}', True),


### PR DESCRIPTION
Hi @aronasorman and @MCGallaspy  - this fixes https://github.com/learningequality/ka-lite/issues/3075 .

This fix can solve css classes that has been 18nize even we don't want to

The image below demonstrate the following blocks that we want i18nize and the blocks that we don't want to.
It is presented by the highlighted line.

Before the `i18n-ize templates script` run
![screen shot 2015-03-02 at 1 34 24 pm](https://cloud.githubusercontent.com/assets/4099119/6436435/416d1c94-c0ea-11e4-8013-465a3d8e01da.png)

After  the `i18n-ize templates script` run
![screen shot 2015-03-02 at 1 50 23 pm](https://cloud.githubusercontent.com/assets/4099119/6458630/bfe8164c-c1c0-11e4-95fd-f4a4a195fb0c.png)

Therefore this marker block `{% block i18n_do_not_translate %}` can ignore some labels and css classes that we don't want to `i18n-ize`.

To Replicate
Refer to this example https://github.com/learningequality/ka-lite/wiki/Internationalization:-Coding#i18nize_templates-management-command

Note: 

> Clone and install this tool : https://github.com/fle-internal/i18nize_templates/tree/master

Example Replication

> ```
> python manage.py i18nize_templates control_panel --parse-file device_management.html
> ```
> 
> Check file `~/ka-lite/kalite/control_panel/templates/control_panel/account_management.html`
> Note that our `css classes` are not translated to our 18nize format because our `css classes` where
> wrapped with our maker block `{% block i18n_do_not_translate %}`
